### PR TITLE
Update to Caffeine 3.2.0, reworking the API to match Caffeine's.

### DIFF
--- a/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/CaffeineExtensions.kt
+++ b/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/CaffeineExtensions.kt
@@ -8,13 +8,13 @@ import dev.hsbrysk.caffeine.internal.toAsyncCacheLoader
 /**
  * Build [CoroutineCache]
  */
-fun <K : Any, V : Any> Caffeine<in K, in V>.buildCoroutine(): CoroutineCache<K, V> =
+fun <K : Any, V> Caffeine<in K, in V & Any>.buildCoroutine(): CoroutineCache<K, V> =
     CoroutineCacheImpl(this.buildAsync())
 
 /**
  * Build [CoroutineLoadingCache]
  */
-fun <K : Any, V : Any> Caffeine<in K, in V>.buildCoroutine(
+fun <K : Any, V> Caffeine<in K, in V & Any>.buildCoroutine(
     loader: CoroutineCacheLoader<K, V>,
 ): CoroutineLoadingCache<K, V> = CoroutineLoadingCacheImpl(
     CoroutineCacheImpl(this.buildAsync(loader.toAsyncCacheLoader())),

--- a/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/CoroutineCache.kt
+++ b/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/CoroutineCache.kt
@@ -3,7 +3,7 @@ package dev.hsbrysk.caffeine
 import com.github.benmanes.caffeine.cache.AsyncCache
 import com.github.benmanes.caffeine.cache.Cache
 
-interface CoroutineCache<K : Any, V : Any> {
+interface CoroutineCache<K : Any, V> {
     /**
      * The coroutines implementation of [Cache.getIfPresent]
      */
@@ -14,29 +14,29 @@ interface CoroutineCache<K : Any, V : Any> {
      */
     suspend fun get(
         key: K,
-        mappingFunction: suspend (K) -> V?,
-    ): V?
+        mappingFunction: suspend (K) -> V,
+    ): V
 
     /**
      * The coroutines implementation of [Cache.getAll]
      */
     suspend fun getAll(
         keys: Iterable<K>,
-        mappingFunction: suspend (Iterable<K>) -> Map<K, V>,
-    ): Map<K, V>
+        mappingFunction: suspend (Iterable<K>) -> Map<K, V & Any>,
+    ): Map<K, V & Any>
 
     /**
      * The coroutines implementation of [Cache.put]
      */
     fun put(
         key: K,
-        value: V,
+        value: V & Any,
     )
 
     /**
      * The coroutines implementation of [Cache.putAll]
      */
-    fun putAll(map: Map<K, V>)
+    fun putAll(map: Map<K, V & Any>)
 
     /**
      * Returns the [Cache]

--- a/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/CoroutineCacheBulkLoader.kt
+++ b/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/CoroutineCacheBulkLoader.kt
@@ -2,9 +2,9 @@ package dev.hsbrysk.caffeine
 
 import com.github.benmanes.caffeine.cache.CacheLoader
 
-interface CoroutineCacheBulkLoader<K : Any, V : Any> : CoroutineCacheLoader<K, V> {
+interface CoroutineCacheBulkLoader<K : Any, V> : CoroutineCacheLoader<K, V> {
     /**
      * The coroutines implementation of [CacheLoader.loadAll]
      */
-    suspend fun loadAll(keys: Set<K>): Map<K, V>
+    suspend fun loadAll(keys: Set<K>): Map<K, V & Any>
 }

--- a/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/CoroutineCacheLoader.kt
+++ b/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/CoroutineCacheLoader.kt
@@ -2,17 +2,17 @@ package dev.hsbrysk.caffeine
 
 import com.github.benmanes.caffeine.cache.CacheLoader
 
-fun interface CoroutineCacheLoader<K : Any, V : Any> {
+fun interface CoroutineCacheLoader<K : Any, V> {
     /**
      * The coroutines implementation of [CacheLoader.load]
      */
-    suspend fun load(key: K): V?
+    suspend fun load(key: K): V
 
     /**
      * The coroutines implementation of [CacheLoader.reload]
      */
     suspend fun reload(
         key: K,
-        oldValue: V,
-    ): V? = load(key)
+        oldValue: V & Any,
+    ): V = load(key)
 }

--- a/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/CoroutineLoadingCache.kt
+++ b/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/CoroutineLoadingCache.kt
@@ -5,18 +5,18 @@ import com.github.benmanes.caffeine.cache.LoadingCache
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 
-interface CoroutineLoadingCache<K : Any, V : Any> : CoroutineCache<K, V> {
+interface CoroutineLoadingCache<K : Any, V> : CoroutineCache<K, V> {
     /**
      * The coroutines implementation of [LoadingCache.get]
      */
-    suspend fun get(key: K): V?
+    suspend fun get(key: K): V
 
     /**
      * The coroutines implementation of [LoadingCache.getAll]
      * Attention: It is executed for each key using [CoroutineScope.async].
      *   There is a cooperative cancel, so if an error occurs on any key, the other async executions are canceled.
      */
-    suspend fun getAll(keys: Iterable<K>): Map<K, V>
+    suspend fun getAll(keys: Iterable<K>): Map<K, V & Any>
 
     /**
      * Returns the [LoadingCache]

--- a/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/internal/CoroutineAsyncCacheLoaders.kt
+++ b/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/internal/CoroutineAsyncCacheLoaders.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.future.future
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 
-internal fun <K : Any, V : Any> CoroutineCacheLoader<K, V>.toAsyncCacheLoader(): AsyncCacheLoader<K, V> =
+internal fun <K : Any, V> CoroutineCacheLoader<K, V>.toAsyncCacheLoader(): AsyncCacheLoader<K, V> =
     if (this is CoroutineCacheBulkLoader<K, V>) {
         CoroutineAsyncCacheBulkLoader(this)
     } else {
@@ -17,29 +17,30 @@ internal fun <K : Any, V : Any> CoroutineCacheLoader<K, V>.toAsyncCacheLoader():
     }
 
 @Suppress("OPT_IN_USAGE")
-private open class CoroutineAsyncCacheLoader<K : Any, V : Any>(private val loader: CoroutineCacheLoader<K, V>) :
+private open class CoroutineAsyncCacheLoader<K : Any, V>(private val loader: CoroutineCacheLoader<K, V>) :
     AsyncCacheLoader<K, V> {
 
     override fun asyncLoad(
         key: K,
         executor: Executor,
-    ): CompletableFuture<V?> = GlobalScope.future(executor.asCoroutineDispatcher()) { loader.load(key) }
+    ): CompletableFuture<out V> = GlobalScope.future(executor.asCoroutineDispatcher()) { loader.load(key) }
 
     override fun asyncReload(
         key: K,
-        oldValue: V,
+        oldValue: V & Any,
         executor: Executor,
-    ): CompletableFuture<V?> = GlobalScope.future(executor.asCoroutineDispatcher()) {
+    ): CompletableFuture<out V> = GlobalScope.future(executor.asCoroutineDispatcher()) {
         loader.reload(key, oldValue)
     }
 }
 
 @Suppress("OPT_IN_USAGE")
-private class CoroutineAsyncCacheBulkLoader<K : Any, V : Any>(private val loader: CoroutineCacheBulkLoader<K, V>) :
+private class CoroutineAsyncCacheBulkLoader<K : Any, V>(private val loader: CoroutineCacheBulkLoader<K, V>) :
     CoroutineAsyncCacheLoader<K, V>(loader) {
 
     override fun asyncLoadAll(
         keys: Set<K>,
         executor: Executor,
-    ): CompletableFuture<Map<out K, V>> = GlobalScope.future(executor.asCoroutineDispatcher()) { loader.loadAll(keys) }
+    ): CompletableFuture<Map<out K, V & Any>> =
+        GlobalScope.future(executor.asCoroutineDispatcher()) { loader.loadAll(keys) }
 }

--- a/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/internal/CoroutineCacheImpl.kt
+++ b/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/internal/CoroutineCacheImpl.kt
@@ -8,31 +8,31 @@ import kotlinx.coroutines.future.await
 import kotlinx.coroutines.future.future
 import java.util.concurrent.CompletableFuture
 
-internal class CoroutineCacheImpl<K : Any, V : Any>(private val cache: AsyncCache<K, V>) : CoroutineCache<K, V> {
+internal class CoroutineCacheImpl<K : Any, V>(private val cache: AsyncCache<K, V>) : CoroutineCache<K, V> {
     override suspend fun getIfPresent(key: K): V? = cache.getIfPresent(key)?.await()
 
     override suspend fun get(
         key: K,
-        mappingFunction: suspend (K) -> V?,
-    ): V? = coroutineScope {
+        mappingFunction: suspend (K) -> V,
+    ): V = coroutineScope {
         cache.get(key) { k, _ -> future { mappingFunction(k) } }.await()
     }
 
     override suspend fun getAll(
         keys: Iterable<K>,
-        mappingFunction: suspend (Iterable<K>) -> Map<K, V>,
-    ): Map<K, V> = coroutineScope {
+        mappingFunction: suspend (Iterable<K>) -> Map<K, V & Any>,
+    ): Map<K, V & Any> = coroutineScope {
         cache.getAll(keys) { k, _ -> future { mappingFunction(k) } }.await()
     }
 
     override fun put(
         key: K,
-        value: V,
+        value: V & Any,
     ) {
         cache.put(key, CompletableFuture.completedFuture(value))
     }
 
-    override fun putAll(map: Map<K, V>) {
+    override fun putAll(map: Map<K, V & Any>) {
         map.entries.forEach { cache.put(it.key, CompletableFuture.completedFuture(it.value)) }
     }
 

--- a/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/internal/CoroutineLoadingCacheImpl.kt
+++ b/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/internal/CoroutineLoadingCacheImpl.kt
@@ -10,22 +10,22 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 
-internal class CoroutineLoadingCacheImpl<K : Any, V : Any>(
+internal class CoroutineLoadingCacheImpl<K : Any, V>(
     private val cache: CoroutineCache<K, V>,
     private val loader: CoroutineCacheLoader<K, V>,
 ) : CoroutineLoadingCache<K, V>,
     CoroutineCache<K, V> by cache {
     private val bulkLoader = loader as? CoroutineCacheBulkLoader<K, V>
 
-    override suspend fun get(key: K): V? = cache.get(key) { loader.load(it) }
+    override suspend fun get(key: K): V = cache.get(key) { loader.load(it) }
 
     @Suppress("UNCHECKED_CAST")
-    override suspend fun getAll(keys: Iterable<K>): Map<K, V> = if (bulkLoader == null) {
+    override suspend fun getAll(keys: Iterable<K>): Map<K, V & Any> = if (bulkLoader == null) {
         coroutineScope {
             keys.map { async { it to get(it) } }
                 .awaitAll()
                 .toMap()
-                .filterValues { it != null } as Map<K, V>
+                .filterValues { it != null } as Map<K, V & Any>
         }
     } else {
         cache.getAll(keys) { bulkLoader.loadAll(keys.toSet()) }

--- a/caffeine-coroutines/src/test/kotlin/dev/hsbrysk/caffeine/internal/CoroutineCacheImplTest.kt
+++ b/caffeine-coroutines/src/test/kotlin/dev/hsbrysk/caffeine/internal/CoroutineCacheImplTest.kt
@@ -32,7 +32,7 @@ import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
 
 class CoroutineCacheImplTest {
-    private val target = Caffeine.newBuilder().buildCoroutine<String, String>()
+    private val target = Caffeine.newBuilder().buildCoroutine<String, String?>()
     private val invokedKeys = Collections.synchronizedList(mutableListOf<String>())
     private val mappingFunction: suspend (String) -> String = {
         delay(2000)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ ktlint = "1.5.0"
 
 [libraries]
 assertk = { module = "com.willowtreeapps.assertk:assertk-jvm", version = "0.28.1" }
-caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.1.8" }
+caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.2.0" }
 junit-bom = { module = "org.junit:junit-bom", version = "5.11.4" }
 kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
 kotlin-coroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "kotlin-coroutines" }


### PR DESCRIPTION
This PR lets users of caffeine-coroutines, like users of Caffeine 3.2.0,
use the type system to distinguish between caches whose computations can
return `null` and those who can't.

The disadvantage to this change is that it, like the change to Caffeine
3.2.0, requires callers to update their code if they want their cache
computations to return null values: If they want that, they now have to
declare their caches and cache loaders with a value type of `Foo?`
instead of `Foo`.
