### PR TITLE
Update to Caffeine 3.2.0, keeping the API similar.

### DIFF
--- a/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/CoroutineCache.kt
+++ b/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/CoroutineCache.kt
@@ -41,10 +41,10 @@ interface CoroutineCache<K : Any, V : Any> {
     /**
      * Returns the [Cache]
      */
-    fun synchronous(): Cache<K, V>
+    fun synchronous(): Cache<K, V?>
 
     /**
      * Returns the [AsyncCache]
      */
-    fun asynchronous(): AsyncCache<K, V>
+    fun asynchronous(): AsyncCache<K, V?>
 }

--- a/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/CoroutineLoadingCache.kt
+++ b/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/CoroutineLoadingCache.kt
@@ -21,10 +21,10 @@ interface CoroutineLoadingCache<K : Any, V : Any> : CoroutineCache<K, V> {
     /**
      * Returns the [LoadingCache]
      */
-    override fun synchronous(): LoadingCache<K, V>
+    override fun synchronous(): LoadingCache<K, V?>
 
     /**
      * Returns the [AsyncLoadingCache]
      */
-    override fun asynchronous(): AsyncLoadingCache<K, V>
+    override fun asynchronous(): AsyncLoadingCache<K, V?>
 }

--- a/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/internal/CoroutineAsyncCacheLoaders.kt
+++ b/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/internal/CoroutineAsyncCacheLoaders.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.future.future
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 
-internal fun <K : Any, V : Any> CoroutineCacheLoader<K, V>.toAsyncCacheLoader(): AsyncCacheLoader<K, V> =
+internal fun <K : Any, V : Any> CoroutineCacheLoader<K, V>.toAsyncCacheLoader(): AsyncCacheLoader<K, V?> =
     if (this is CoroutineCacheBulkLoader<K, V>) {
         CoroutineAsyncCacheBulkLoader(this)
     } else {
@@ -18,18 +18,18 @@ internal fun <K : Any, V : Any> CoroutineCacheLoader<K, V>.toAsyncCacheLoader():
 
 @Suppress("OPT_IN_USAGE")
 private open class CoroutineAsyncCacheLoader<K : Any, V : Any>(private val loader: CoroutineCacheLoader<K, V>) :
-    AsyncCacheLoader<K, V> {
+    AsyncCacheLoader<K, V?> {
 
     override fun asyncLoad(
         key: K,
         executor: Executor,
-    ): CompletableFuture<V?> = GlobalScope.future(executor.asCoroutineDispatcher()) { loader.load(key) }
+    ): CompletableFuture<out V?> = GlobalScope.future(executor.asCoroutineDispatcher()) { loader.load(key) }
 
     override fun asyncReload(
         key: K,
         oldValue: V,
         executor: Executor,
-    ): CompletableFuture<V?> = GlobalScope.future(executor.asCoroutineDispatcher()) {
+    ): CompletableFuture<out V?> = GlobalScope.future(executor.asCoroutineDispatcher()) {
         loader.reload(key, oldValue)
     }
 }

--- a/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/internal/CoroutineCacheImpl.kt
+++ b/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/internal/CoroutineCacheImpl.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.future.await
 import kotlinx.coroutines.future.future
 import java.util.concurrent.CompletableFuture
 
-internal class CoroutineCacheImpl<K : Any, V : Any>(private val cache: AsyncCache<K, V>) : CoroutineCache<K, V> {
+internal class CoroutineCacheImpl<K : Any, V : Any>(private val cache: AsyncCache<K, V?>) : CoroutineCache<K, V> {
     override suspend fun getIfPresent(key: K): V? = cache.getIfPresent(key)?.await()
 
     override suspend fun get(
@@ -36,7 +36,7 @@ internal class CoroutineCacheImpl<K : Any, V : Any>(private val cache: AsyncCach
         map.entries.forEach { cache.put(it.key, CompletableFuture.completedFuture(it.value)) }
     }
 
-    override fun synchronous(): Cache<K, V> = cache.synchronous()
+    override fun synchronous(): Cache<K, V?> = cache.synchronous()
 
-    override fun asynchronous(): AsyncCache<K, V> = cache
+    override fun asynchronous(): AsyncCache<K, V?> = cache
 }

--- a/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/internal/CoroutineLoadingCacheImpl.kt
+++ b/caffeine-coroutines/src/main/kotlin/dev/hsbrysk/caffeine/internal/CoroutineLoadingCacheImpl.kt
@@ -31,7 +31,7 @@ internal class CoroutineLoadingCacheImpl<K : Any, V : Any>(
         cache.getAll(keys) { bulkLoader.loadAll(keys.toSet()) }
     }
 
-    override fun synchronous(): LoadingCache<K, V> = asynchronous().synchronous()
+    override fun synchronous(): LoadingCache<K, V?> = asynchronous().synchronous()
 
-    override fun asynchronous(): AsyncLoadingCache<K, V> = cache.asynchronous() as AsyncLoadingCache<K, V>
+    override fun asynchronous(): AsyncLoadingCache<K, V?> = cache.asynchronous() as AsyncLoadingCache<K, V?>
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ ktlint = "1.5.0"
 
 [libraries]
 assertk = { module = "com.willowtreeapps.assertk:assertk-jvm", version = "0.28.1" }
-caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.1.8" }
+caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.2.0" }
 junit-bom = { module = "org.junit:junit-bom", version = "5.11.4" }
 kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
 kotlin-coroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "kotlin-coroutines" }


### PR DESCRIPTION
This PR continues to require that all users of the cache be prepared for
cache computations to return `null`.

The advantage is that the API looks exactly the same to callers (except
for `synchronous()` and `asynchronous()`, which now return caches with
nullable types for consistency). The disadvantage is that we could
probably do better by making the same distinction as Caffeine now does:
We can use the type system to distinguish between caches whose
computations can return `null` and those who can't.
