### PR TITLE
Downgrade kotlin to 2.0.x

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin-core = "2.1.10"
-kotlin-coroutines = "1.10.1"
+kotlin-core = "2.0.21"
+kotlin-coroutines = "1.9.0"
 ktlint = "1.5.0"
 
 [libraries]


### PR DESCRIPTION
Kotlin 2.1 has just been released.  
Meanwhile, many server-side Kotlin users are still using **1.9**, mainly due to Spring Boot dependencies.  

Since Kotlin does not guarantee binary compatibility when versions are two releases apart, we will continue to maintain **2.0** for the time being.
https://kotlinlang.org/docs/kotlin-evolution-principles.html#evolving-the-binary-format