### PR TITLE
Harden supply chain security for GitHub Actions and Renovate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,14 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
           java-version: 17
       - name: Set up gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: Check
         run: ./gradlew check
 
@@ -32,11 +32,11 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
           java-version: 17
       - name: Report gradle dependencies diff
-        uses: be-hase/gradle-dependency-diff-action@v2
+        uses: be-hase/gradle-dependency-diff-action@b371bc71a47779fea4ca94a39a3c968137057d6b # v2.0.1

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -10,14 +10,14 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
           java-version: 17
       - name: Set up gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: Publish
         env:
           TAG_NAME: ${{ github.ref_name }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,5 +4,12 @@
     "config:recommended"
   ],
   automerge: true,
+  "major": {
+    "automerge": false
+  },
+  // Supply chain mitigation: don't pick up a release until it has been public for a while,
+  // so compromised versions are usually detected and unpublished before automerge sees them.
+  // Renovate's vulnerabilityAlerts updates bypass this delay by default.
+  "minimumReleaseAge": "7 days",
   "labels": ["renovate"],
 }


### PR DESCRIPTION
## Summary
- Pin GitHub Actions to full commit SHAs (with version comments) instead of mutable version tags in `ci.yml` and `publish-maven-central.yml`
- Disable Renovate automerge for major updates
- Add `minimumReleaseAge: 7 days` to Renovate so compromised releases are usually detected and unpublished before automerge picks them up (vulnerability alert updates still bypass this delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)